### PR TITLE
use go/zap for logging

### DIFF
--- a/g2krelay/go.mod
+++ b/g2krelay/go.mod
@@ -3,3 +3,8 @@ module github.com/yourusername/g2krelay
 go 1.23.1
 
 require github.com/confluentinc/confluent-kafka-go/v2 v2.5.4
+
+require (
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+)

--- a/g2krelay/go.sum
+++ b/g2krelay/go.sum
@@ -324,6 +324,10 @@ go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lI
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
 golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=

--- a/g2krepeater/go.mod
+++ b/g2krepeater/go.mod
@@ -3,3 +3,8 @@ module github.com/yourusername/g2kconsumer
 go 1.23.1
 
 require github.com/confluentinc/confluent-kafka-go/v2 v2.5.4
+
+require (
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+)

--- a/g2krepeater/go.sum
+++ b/g2krepeater/go.sum
@@ -324,6 +324,10 @@ go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lI
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
 golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=


### PR DESCRIPTION
## What
#2 

## Example logs
`g2krelay`:
```
{"level":"info","ts":1739161249.0773582,"caller":"app/main.go:48","msg":"Starting g2krelay server","port":"5050"}
{"level":"info","ts":1739161683.8939836,"caller":"app/main.go:245","msg":"Topic status","topic":"github.events","status":"The topic has already been created"}
{"level":"info","ts":1739161683.9035358,"caller":"app/main.go:189","msg":"Message delivered to Kafka","topic":"github.events","partition":0,"offset":"2"}
```

`g2krepeater`:
```
{"level":"info","ts":1739162628.9972715,"caller":"app/main.go:184","msg":"Kafka config loaded","key":"bootstrap.servers","value":"redpanda:9092"}
{"level":"info","ts":1739162628.9972942,"caller":"app/main.go:184","msg":"Kafka config loaded","key":"group.id","value":"g2krepeater-group"}
{"level":"info","ts":1739162628.9987526,"caller":"app/main.go:47","msg":"Consumer started. Waiting for messages..."}
{"level":"info","ts":1739162647.0676215,"caller":"app/main.go:160","msg":"Message sent successfully","key":"vigneshrajsb.backend-svc.pull_request","endpoint":"http://webhook-server.default.svc.cluster.local/webhook","status":200}
```