### PR TITLE
chore: update image for redpanda

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,7 +1,7 @@
 redpanda:
   enabled: true
   replicas: 1
-  image: "vectorized/redpanda:latest"
+  image: "redpandadata/redpanda:latest"
   containerPort: 9092
   overprovisioned: true
   smp: 1


### PR DESCRIPTION
## What
updates the image used 

refer: https://support.redpanda.com/hc/en-us/articles/28494748119959-TSB-2024-14-The-legacy-Vectorized-repositories-have-been-removed?utm_source=chatgpt.com