### PR TITLE
fix: handle custom values for the new repeaters setup

### DIFF
--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -28,7 +28,10 @@ Create g2krelay image
 Create g2krepeater image
 */}}
 {{- define "g2k.g2krepeater.image" -}}
-{{- include "g2k.image" (dict "imageConfig" .imageConfig "chartAppVersion" .chartAppVersion) -}}
+{{- $imageConfig := .imageConfig | default dict -}}
+{{- $repository := $imageConfig.repository | default "vmelikyan/g2krepeater" -}}
+{{- $tag := $imageConfig.tag | default .chartAppVersion -}}
+{{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 
 {{/*

--- a/helm/chart/templates/g2krepeater-deployment.yaml
+++ b/helm/chart/templates/g2krepeater-deployment.yaml
@@ -1,8 +1,8 @@
 {{- /* Handle backward compatibility - convert old single g2krepeater to new format */}}
 {{- $g2krepeaters := .Values.g2krepeaters }}
-{{- if and .Values.g2krepeater.enabled (not $g2krepeaters) }}
+{{- if and ((.Values.g2krepeater).enabled | default false) (not $g2krepeaters) }}
   {{- $g2krepeaters = dict "default" .Values.g2krepeater }}
-{{- else if and .Values.g2krepeater.enabled (not (hasKey $g2krepeaters "default")) }}
+{{- else if and ((.Values.g2krepeater).enabled | default false) (not (hasKey $g2krepeaters "default")) }}
   {{- $_ := set $g2krepeaters "default" .Values.g2krepeater }}
 {{- end }}
 

--- a/helm/chart/templates/g2krepeater-service.yaml
+++ b/helm/chart/templates/g2krepeater-service.yaml
@@ -1,8 +1,8 @@
 {{- /* Handle backward compatibility - convert old single g2krepeater to new format */}}
 {{- $g2krepeaters := .Values.g2krepeaters }}
-{{- if and .Values.g2krepeater.enabled (not $g2krepeaters) }}
+{{- if and ((.Values.g2krepeater).enabled | default false) (not $g2krepeaters) }}
   {{- $g2krepeaters = dict "default" .Values.g2krepeater }}
-{{- else if and .Values.g2krepeater.enabled (not (hasKey $g2krepeaters "default")) }}
+{{- else if and ((.Values.g2krepeater).enabled | default false) (not (hasKey $g2krepeaters "default")) }}
   {{- $_ := set $g2krepeaters "default" .Values.g2krepeater }}
 {{- end }}
 

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -3,7 +3,7 @@ redpanda:
   replicas: 1
   image:
     repository: redpandadata/redpanda
-    tag: ""  # Defaults to latest if not specified
+    tag: "" # Defaults to latest if not specified
   containerPort: 9092
   overprovisioned: true
   smp: 1
@@ -19,7 +19,7 @@ redpandaConsole:
   enabled: true
   image:
     repository: redpandadata/console
-    tag: ""  # Defaults to latest if not specified
+    tag: "" # Defaults to latest if not specified
   replicas: 1
   kafkaBrokers: "redpanda.lifecycle-app.svc.cluster.local:9092"
 
@@ -28,7 +28,7 @@ g2krelay:
   replicas: 1
   image:
     repository: vmelikyan/g2krelay
-    tag: ""  # Defaults to Chart.AppVersion if not specified
+    tag: "" # Defaults to Chart.AppVersion if not specified
   serviceType: ClusterIP
   servicePort: 5050
   envVars:
@@ -43,14 +43,14 @@ g2krelay:
     tls: []
 
 g2krepeaters: {}
-
-g2krepeater:
-  enabled: true
-  replicas: 1
-  image:
-    repository: vmelikyan/g2krepeater
-    tag: ""  # Defaults to Chart.AppVersion if not specified
-  envVars:
-    KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
-    KAFKA_GROUP_ID: "g2krepeater-default"
-    REPLAY_ENDPOINTS: ""
+# Legacy single g2krepeater configuration (for backward compatibility)
+# g2krepeater:
+#   enabled: false
+#   replicas: 1
+#   image:
+#     repository: vmelikyan/g2krepeater
+#     tag: ""  # Defaults to Chart.AppVersion if not specified
+#   envVars:
+#     KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
+#     KAFKA_GROUP_ID: "g2krepeater-default"
+#     REPLAY_ENDPOINTS: ""


### PR DESCRIPTION
### What
- uses `vmelikyan/g2krepeater` as default image repo for `g2krepeaters`
- remove default legacy `g2krepeater` from `values.yaml` to avoid creating unnecessary svc and deploys
- handle default case in new versions when `g2krepeater.enabled` is not set