### PR TITLE
fix: default image tags with prefix

### DIFF
--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -14,6 +14,9 @@ Create image name with tag
 {{- $chartAppVersion := .chartAppVersion -}}
 {{- $defaultTag := .defaultTag | default $chartAppVersion -}}
 {{- $tag := $imageConfig.tag | default $defaultTag -}}
+{{- if and (not $imageConfig.tag) (not (hasPrefix "v" $tag)) (not (eq $tag "latest")) -}}
+{{- $tag = printf "v%s" $tag -}}
+{{- end -}}
 {{- printf "%s:%s" $imageConfig.repository $tag -}}
 {{- end -}}
 
@@ -31,6 +34,9 @@ Create g2krepeater image
 {{- $imageConfig := .imageConfig | default dict -}}
 {{- $repository := $imageConfig.repository | default "vmelikyan/g2krepeater" -}}
 {{- $tag := $imageConfig.tag | default .chartAppVersion -}}
+{{- if and (not $imageConfig.tag) (not (hasPrefix "v" $tag)) (not (eq $tag "latest")) -}}
+{{- $tag = printf "v%s" $tag -}}
+{{- end -}}
 {{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 


### PR DESCRIPTION
### What
- default image tag doesnt include prefix `v` like `v0.4.0`. this should fix it. but this is only a patch. revisit the templates later